### PR TITLE
Fix launch action not usable for configuration without run mode

### DIFF
--- a/com.eclipserunner.plugin/src/com/eclipserunner/views/impl/RunnerView.java
+++ b/com.eclipserunner.plugin/src/com/eclipserunner/views/impl/RunnerView.java
@@ -18,7 +18,9 @@ import org.eclipse.debug.core.ILaunchConfigurationListener;
 import org.eclipse.debug.core.ILaunchManager;
 import org.eclipse.debug.internal.ui.launchConfigurations.LaunchGroupExtension;
 import org.eclipse.jface.action.Action;
+import org.eclipse.jface.action.ActionContributionItem;
 import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.action.IContributionItem;
 import org.eclipse.jface.action.IMenuListener;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.IToolBarManager;
@@ -462,12 +464,25 @@ public class RunnerView extends ViewPart
 
 	private void setupRunMenu(IMenuManager manager, ILaunchNode launchNode) {
 		if (launchNode != null) {
+			boolean anyActionEnabled = false;
 			for(LaunchOtherConfigurationAction otherLaunchAction : launchOtherConfigurationActions) {
 				String mode = otherLaunchAction.getMode();
 				String category = otherLaunchAction.getCategory();
 				if(launchNode.supportsMode(mode, category)) {
 					manager.add(otherLaunchAction);
-					otherLaunchAction.setChecked(mode.equals(launchNode.getDefaultMode()));
+					boolean enable = mode.equals(launchNode.getDefaultMode());
+					otherLaunchAction.setChecked(enable);
+					anyActionEnabled |= enable;
+				}
+			}
+
+			if (!anyActionEnabled) {
+				// No available mode was the nodes default mode. Enable the first mode instead.
+				for (IContributionItem item : manager.getItems()) {
+					if (item instanceof ActionContributionItem) {
+						((ActionContributionItem)item).getAction().setChecked(true);
+						break;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When the view's launch icon is created/updated the selected run mode is either the last used or if the element is new it is the default value "run" mode.

However if a launch configuration does not support the "run" mode the icon will show a disabled Run symbol and whats worse will also disable the icon's drop-down menu whereby it is not possible to change to a supported launch mode.

An example for such a launch type is Java Remote Debugging. It can be launched as "debug" but does not support "run". A possible workaround is to launch the configuration once through the context menu in Runner view. On following selections it will restore the last used mode which is now "debug".

My proposed change simply checks if one of the available launch modes is selected (either the previous used type or the default "run") and if not enables the first available mode.